### PR TITLE
Remove unused authorization method

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -14,15 +14,4 @@ class WebhooksController < ApplicationController
     end
     head :ok
   end
-
-  private
-  def authorize(status, authentication)
-    string = "#{status.name}#{User.find_or_create_by_username(status.username).travis_token}"
-    if Digest::SHA256.new.hexdigest(string) == authentication
-      true
-    else
-      Rails.logger.warn "AUTH FAILURE: #{status.name} with: #{authentication}"
-      true
-    end
-  end
 end


### PR DESCRIPTION
Was never finished, and isn't used.

Travis uses a user token to verify, but that's the user who added the repo to Travis, not anything handy. They say they plan to change it eventually. :/