### PR TITLE
Add a simple particle webhook controller

### DIFF
--- a/app/controllers/particle_controller.rb
+++ b/app/controllers/particle_controller.rb
@@ -1,0 +1,6 @@
+class ParticleController < ApplicationController
+  def create
+    Particle.publish(name: "build_state", data: Status.current_status, ttl: 3600, private: false)
+    head :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get 'what-is-red/:id(.:format)' => 'red#show'
   get 'what-is-red(.:format)' => 'red#index'
 
+  post 'particle' => 'particle#create'
+
   get ':id(.:format)' => 'colors#show'
   get '/(.:format)' => 'colors#index'
   post '/' => 'webhooks#create'

--- a/particle/buildlight.ino
+++ b/particle/buildlight.ino
@@ -16,6 +16,7 @@ void setup() {
 
   // Subscribe to events
   Particle.subscribe("build_state", stateHandler);
+  Particle.publish("ready", "true", PRIVATE);
 }
 
 void loop() {

--- a/spec/controllers/particle_controller_spec.rb
+++ b/spec/controllers/particle_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe ParticleController do
+  describe 'POST create' do
+    before do
+      allow(Particle).to receive(:publish)
+    end
+
+    it 'notifies Particle' do
+      expect(Particle).to receive(:publish).with({name: "build_state", data: "passing", ttl: 3600, private: false})
+      post :create, {name: "ready", data: "true", coreid: "abc123", published_at: "2016-06-14T22:06:10.976Z"}
+    end
+  end
+end


### PR DESCRIPTION
This makes it so that when the stoplight starts up, it quickly gets an initial state, instead of waiting for a build.

Right now this is pretty basic but once we round out multi device support we can do better here.

There are 3 parts to this.
- The publish call in the particle sketch on startup. (Already installed)
- The build light callback response.
- An integration configured on the particle dashboard. (Already configured)

NOTE: This is currently deployed on Heroku as I needed to see what would work.