### PR TITLE
Switch particle hooks to a generic URL

### DIFF
--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,5 +1,5 @@
-class ParticleController < ApplicationController
-  def create
+class API::DevicesController < ApplicationController
+  def trigger
     Particle.publish(name: "build_state", data: Status.current_status, ttl: 3600, private: false)
     head :ok
   end

--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -1,6 +1,6 @@
 class API::DevicesController < ApplicationController
   def trigger
-    Particle.publish(name: "build_state", data: Status.current_status, ttl: 3600, private: false)
+    TriggerParticle.call(Status.current_status)
     head :ok
   end
 end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -10,7 +10,7 @@ class WebhooksController < ApplicationController
       @status.status_code  = json["status_message"]
       Rails.logger.warn "AUTH: #{@status.name} with: #{request.headers['Authorization']}"
       @status.save!
-      Particle.publish(name: "build_state", data: Status.current_status, ttl: 3600, private: false)
+      TriggerParticle.call(Status.current_status)
     end
     head :ok
   end

--- a/app/interactors/trigger_particle.rb
+++ b/app/interactors/trigger_particle.rb
@@ -1,0 +1,5 @@
+class TriggerParticle
+  def self.call(status)
+    Particle.publish(name: "build_state", data: status, ttl: 3600, private: false)
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,15 @@
 Rails.application.routes.draw do
   get '/.well-known/acme-challenge/:id' => 'pages#letsencrypt'
 
+  # use a namespace to avoid resources colliding with usernames
+  namespace :api do
+    resources :devices, only: [] do
+      post :trigger
+    end
+  end
+
   get 'what-is-red/:id(.:format)' => 'red#show'
   get 'what-is-red(.:format)' => 'red#index'
-
-  post 'particle' => 'particle#create'
 
   get ':id(.:format)' => 'colors#show'
   get '/(.:format)' => 'colors#index'

--- a/spec/controllers/api/devices_controller_spec.rb
+++ b/spec/controllers/api/devices_controller_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-describe ParticleController do
-  describe 'POST create' do
+describe API::DevicesController do
+  describe 'POST trigger' do
     before do
       allow(Particle).to receive(:publish)
     end
 
     it 'notifies Particle' do
       expect(Particle).to receive(:publish).with({name: "build_state", data: "passing", ttl: 3600, private: false})
-      post :create, {name: "ready", data: "true", coreid: "abc123", published_at: "2016-06-14T22:06:10.976Z"}
+      post :trigger, device_id: "abc123", name: "ready", data: "true", coreid: "abc123", published_at: "2016-06-14T22:06:10.976Z"
     end
   end
 end


### PR DESCRIPTION
TODO:
- [ ] change URL particle uses. how do we do that?

This is my idea of what the particle device should do. I'm using a generic `api` url namespace so we don't clutter the top level namespace with routes that might conflict with usernames.