### PR TITLE
Remove extraneous data from red json

### DIFF
--- a/app/controllers/api/red_controller.rb
+++ b/app/controllers/api/red_controller.rb
@@ -4,7 +4,7 @@ class API::RedController < ApplicationController
     @red_projects = device.statuses.where(red: true)
     respond_to do |format|
       format.html
-      format.json { render json: @red_projects }
+      format.json { render json: @red_projects.to_json(only: [:username, :project_name]) }
     end
   end
 end

--- a/spec/controllers/api/red_controller_spec.rb
+++ b/spec/controllers/api/red_controller_spec.rb
@@ -23,7 +23,8 @@ describe API::RedController do
     it "responds with the list of red projects serialized as json" do
       get :show, params: {id: 'abc123', format: :json}
 
-      expect(response.body).to eq([red1].to_json)
+      response_json = JSON.parse(response.body)
+      expect(response_json).to match_array([{"project_name" => red1.project_name, "username" => red1.username}])
     end
   end
 end


### PR DESCRIPTION
This was showing full info from the webhook which includes emails and commit messages. We never want to display that.