### PR TITLE
Animate the lightbulbs

### DIFF
--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -1,3 +1,4 @@
 @import "variables";
 @import "reset";
 @import "elements";
+@import "keyframes";

--- a/app/assets/stylesheets/base/_elements.scss
+++ b/app/assets/stylesheets/base/_elements.scss
@@ -3,6 +3,7 @@
 
 html {
   font-family: $base-font-family;
+  font-weight: 300;
   line-height: 1.4;
 }
 

--- a/app/assets/stylesheets/base/_keyframes.scss
+++ b/app/assets/stylesheets/base/_keyframes.scss
@@ -1,0 +1,3 @@
+@keyframes pulse {
+  50% { transform: scale(.8); }
+}

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -28,3 +28,6 @@ $bulb-size: 50vmin;
 $bulb-shadow-size: 150vmax;
 $bulb-gutter: 6vmin;
 $light-height: ($bulb-size * 3) + ($bulb-gutter * 2);
+
+// Animations
+$animation-pulse-duration: 5s;

--- a/app/assets/stylesheets/components/_bulb.scss
+++ b/app/assets/stylesheets/components/_bulb.scss
@@ -7,6 +7,7 @@
   width: $bulb-size;
 
   &__glow {
+    animation: pulse $animation-pulse-duration infinite;
     display: block;
     height: $bulb-shadow-size;
     left: 50%;
@@ -19,15 +20,11 @@
     transition: transform $slow-transition-speed, opacity $slow-transition-speed;
     transition-delay: $fast-transition-speed;
     width: $bulb-shadow-size;
-    z-index: 1;
+    z-index: 2;
 
-    // Ensure that the building bulb's glow doesn't overpower
-    // the other lights, if/when they're also on
-    [data-failing][data-building] .bulb--yellow &,
-    [data-passing][data-building] .bulb--yellow & {
-      opacity: .2;
-      transform: scale(.75);
-    }
+    // 1 - Make sure the building glow displays underneath the
+    //     passing/failing glows; they should take precedence
+    .bulb--yellow & { z-index: 1; } // 1
   }
 
   &__disc {
@@ -39,7 +36,7 @@
     right: 0;
     top: 0;
     transition: background-color $fast-transition-speed;
-    z-index: 2;
+    z-index: 3;
   }
 
   &__text {
@@ -56,7 +53,7 @@
     top: $bulb-size / 2;
     transition: opacity $base-transition-speed;
     width: $bulb-size;
-    z-index: 3;
+    z-index: 4;
   }
 
   @mixin bulb($color, $state) {
@@ -64,7 +61,9 @@
       .bulb__glow {
         background-image: radial-gradient(
           ellipse at center,
+          rgba($color, .9) 10%,
           rgba($color, .6) 20%,
+          rgba($color, .3) 40%,
           rgba($color, 0) 70%
         );
         opacity: 1;
@@ -77,6 +76,14 @@
   }
 
   &--red { @include bulb($red, "failing"); }
-  &--yellow { @include bulb($yellow, "building"); }
+
+  &--yellow {
+    @include bulb($yellow, "building");
+
+    // 1 - offset glow animation so that the building light
+    //     balances well with the failing/passing ones
+    .bulb__glow { animation-delay: -($animation-pulse-duration / 2); } // 1
+  }
+
   &--green { @include bulb($green, "passing"); }
 }

--- a/app/assets/stylesheets/components/_light.scss
+++ b/app/assets/stylesheets/components/_light.scss
@@ -35,5 +35,10 @@
     [data-passing][data-building] & {
       margin-top: -($bulb-size + $bulb-gutter) / 2;
     }
+
+    [data-failing][data-passing] & {
+      margin-top: 0;
+      transform: scale(.75);
+    }
   }
 }

--- a/app/assets/stylesheets/components/_message.scss
+++ b/app/assets/stylesheets/components/_message.scss
@@ -10,6 +10,8 @@
   &__footer {
     font-size: .8em;
     opacity: .5;
+
+    :first-child { margin-top: 0; }
   }
 }
 
@@ -31,6 +33,7 @@
 
   > :first-child {
     font-size: 1.5em;
+    line-height: 1.2;
     margin-bottom: .25em;
   }
 


### PR DESCRIPTION
This PR adds a subtle “pulse” animation to the traffic lights. These animations look pretty rad, but they can also be a GPU hog. Should we even consider merging this? It’s your call.

Also included in this PR:
* Lighten body type a bit
* Adjust lightbulb glow layers so that yellow displays underneath red/green
* Adjust light box to allow both red/green to be shown (when we’d need this, idk…)
* Tweak message footer margins