### PR TITLE
Add `id` attribute to favicon

### DIFF
--- a/app/helpers/color_helper.rb
+++ b/app/helpers/color_helper.rb
@@ -29,6 +29,6 @@ module ColorHelper
     end
 
     filename << ".ico"
-    favicon_link_tag(filename)
+    favicon_link_tag filename, id: "favicon"
   end
 end


### PR DESCRIPTION
This fixes a JS error that pops up when the app tries to dynamically
update the favicon.