### PR TITLE
Only trigger devices if status has changed

### DIFF
--- a/app/controllers/api/devices_controller.rb
+++ b/app/controllers/api/devices_controller.rb
@@ -6,9 +6,7 @@ class API::DevicesController < API::ApplicationController
 
   def trigger
     device = Device.find_by(identifier: params[:coreid])
-    if device
-      TriggerParticle.call(device)
-    end
+    device&.trigger
     head :ok
   end
 end

--- a/app/interactors/parse_circle.rb
+++ b/app/interactors/parse_circle.rb
@@ -6,7 +6,6 @@ class ParseCircle
     status.payload = payload if ENV["DEBUG"]
     set_colors(status, payload["status"])
     status.save!
-    status.trigger
   end
 
   # Options

--- a/app/interactors/parse_github.rb
+++ b/app/interactors/parse_github.rb
@@ -6,7 +6,6 @@ class ParseGithub
     status.payload = payload if ENV["DEBUG"]
     set_colors(status, payload["status"])
     status.save!
-    status.trigger
   end
 
   # Options

--- a/app/interactors/parse_travis.rb
+++ b/app/interactors/parse_travis.rb
@@ -9,7 +9,6 @@ class ParseTravis
     status.project_name = json["repository"]["name"]
     set_colors(status, json["status_message"])
     status.save!
-    status.trigger
   end
 
   # Set colors based on travis-ci's status code

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,4 +1,6 @@
 class Status < ApplicationRecord
+  after_commit :update_devices, on: [:create, :update]
+
   def name
     "#{username}/#{project_name}"
   end
@@ -35,10 +37,9 @@ class Status < ApplicationRecord
     [green, red, yellow].compact.join("-") # combines status to send "passing|failing-building"
   end
 
-  # Trigger updates to devices and channels
-  def trigger
+  def update_devices
     ColorsChannel.broadcast_to("*", colors: Status.colors)
     ColorsChannel.broadcast_to(username, colors: Status.colors(username))
-    devices.each(&:trigger)
+    devices.each(&:update_status)
   end
 end

--- a/db/migrate/20230305131208_add_status_to_devices.rb
+++ b/db/migrate/20230305131208_add_status_to_devices.rb
@@ -1,0 +1,6 @@
+class AddStatusToDevices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :devices, :status, :string
+    add_column :devices, :status_changed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_04_144230) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_05_131208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_04_144230) do
     t.string "name", null: false
     t.string "webhook_url"
     t.citext "slug"
+    t.string "status"
+    t.datetime "status_changed_at"
     t.index ["identifier"], name: "index_devices_on_identifier", unique: true
     t.index ["name"], name: "index_devices_on_name"
     t.index ["slug"], name: "index_devices_on_slug", unique: true

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -39,9 +39,10 @@ describe WebhooksController do
       end
 
       it "notifies Particle" do
-        FactoryBot.create(:device, usernames: ["collectiveidea"])
-        expect(Particle).to receive(:publish).with(name: "build_state", data: "passing", ttl: 3600, private: false)
+        FactoryBot.create(:device, :with_identifier, usernames: ["collectiveidea"])
+        allow(Particle).to receive(:publish)
         post :create, params: {payload: json_fixture("travis.json")}
+        expect(Particle).to have_received(:publish).with(name: "build_state", data: "passing", ttl: 3600, private: false)
       end
     end
 
@@ -70,9 +71,10 @@ describe WebhooksController do
       end
 
       it "notifies Particle" do
-        FactoryBot.create(:device, usernames: ["collectiveidea"])
-        expect(Particle).to receive(:publish).with(name: "build_state", data: "passing", ttl: 3600, private: false)
+        FactoryBot.create(:device, :with_identifier, usernames: ["collectiveidea"])
+        allow(Particle).to receive(:publish)
         post :create, params: JSON.parse(json_fixture("circle.json"))
+        expect(Particle).to have_received(:publish).with(name: "build_state", data: "passing", ttl: 3600, private: false)
       end
     end
 
@@ -93,9 +95,10 @@ describe WebhooksController do
       end
 
       it "notifies Particle" do
-        FactoryBot.create(:device, usernames: ["collectiveidea"])
-        expect(Particle).to receive(:publish).with(name: "build_state", data: "passing", ttl: 3600, private: false)
+        FactoryBot.create(:device, :with_identifier, usernames: ["collectiveidea"])
+        allow(Particle).to receive(:publish)
         post :create, params: JSON.parse(json_fixture("github.json"))
+        expect(Particle).to have_received(:publish).with(name: "build_state", data: "passing", ttl: 3600, private: false)
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,8 +3,11 @@ FactoryBot.define do
     usernames { [] }
     projects { [] }
     sequence(:name) { |i| "Device #{i}" }
-    sequence(:identifier) { |i| "device-#{i}" }
     sequence(:slug) { |i| "slug-#{i}" }
+
+    trait :with_identifier do
+      sequence(:identifier) { |i| "device-#{i}" }
+    end
   end
 
   factory :status do

--- a/spec/interactors/trigger_webhook_spec.rb
+++ b/spec/interactors/trigger_webhook_spec.rb
@@ -2,10 +2,13 @@ require "rails_helper"
 
 describe TriggerWebhook do
   describe "triggering a webhook" do
-    let(:device) { FactoryBot.create(:device, usernames: ["hooks"], webhook_url: "https://localhost/fake/path") }
-    let(:status) { FactoryBot.create(:status, username: "hooks", project_name: "buildlight") }
+    let!(:status) { FactoryBot.create(:status, username: "hooks", project_name: "buildlight") }
+    let!(:device) { FactoryBot.create(:device, usernames: ["hooks"]) }
 
     it "it sends a basic webhook" do
+      # Add webhook without triggering callbacks
+      device.update_column(:webhook_url, "https://localhost/fake/path")
+
       allow(Faraday).to receive(:post)
       TriggerWebhook.call(device)
       expect(Faraday).to have_received(:post).with(

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -43,17 +43,20 @@ RSpec.describe Device, type: :model do
       FactoryBot.create(:status, username: "deadmanssnitch", project_name: "bar", red: true, yellow: true)
 
       device = FactoryBot.create(:device, usernames: ["collectiveidea"], projects: ["deadmanssnitch/foo"])
-      expect(device.status).to eq("passing-building")
+      expect(device.reload.status).to eq("passing-building")
 
       FactoryBot.create(:status, username: "collectiveidea", project_name: "baz", red: true, yellow: false)
-      expect(device.status).to eq("failing-building")
+      expect(device.reload.status).to eq("failing-building")
     end
   end
 
   describe "#trigger" do
     context "when the device has a webhook_url" do
       it "sends a webhook" do
-        device = FactoryBot.create(:device, webhook_url: "https://localhost/fake/path")
+        device = FactoryBot.create(:device)
+        # Add webhook without triggering callbacks
+        device.update_column(:webhook_url, "https://localhost/fake/path")
+
         allow(TriggerWebhook).to receive(:call)
         device.trigger
         expect(TriggerWebhook).to have_received(:call).with(device)


### PR DESCRIPTION
Refactor how triggering works to be callback-based.

This should reduce extra webhook traffic, which is something we're trying to limit at the moment. Re-evaluate if/when that changes.