### PR TITLE
Repeat broadcast on subscribe

### DIFF
--- a/app/channels/device_channel.rb
+++ b/app/channels/device_channel.rb
@@ -15,6 +15,14 @@ class DeviceChannel < ApplicationCable::Channel
 
   def initial_broadcast
     # Trigger an initial broadcast.
-    Device.find_by(slug: @slug)&.broadcast
+    Thread.new do
+      device = Device.find_by(slug: @slug)
+      if device
+        5.times do
+          device.broadcast
+          sleep 30
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Due to some connection setup timing shenanigans, broadcasting immediately often doesn't make it to the device. This should give us more consistent results